### PR TITLE
Update head.html

### DIFF
--- a/website/themes/mlir/layouts/partials/head.html
+++ b/website/themes/mlir/layouts/partials/head.html
@@ -20,7 +20,7 @@
 <script src="https://cdn.jsdelivr.net/npm/jquery@3.3.1/dist/jquery.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jquery.easing@1.4.1/jquery.easing.min.js"></script>
 <script src="{{"js/bundle.js" | absURL}}"></script>
-<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 <script type="text/x-mathjax-config">
   MathJax.Hub.Config({
     tex2jax: {


### PR DESCRIPTION
Load MathJax.js over https.  This uses the same CDN as `mlir-www`.
See https://github.com/llvm/mlir-www/commit/38a4ac1c2070794b55d456173657ca75a9f4884c