### PR TITLE
Remove broken links in _index.md

### DIFF
--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -16,17 +16,20 @@ selectively expanded as Tool, Translator, Team, Technology, Target, Tree, Type,
 The CIRCT community is an open and welcoming community.  If you'd like to
 participate, you can do so in a number of different ways:
 
-1) Join our [Discourse Forum](https://llvm.discourse.group/c/Projects-that-want-to-become-official-LLVM-Projects/circt/) on the LLVM Discourse server.  To get a "mailing list" like experience click the bell icon in the upper right and switch to "Watching".  It is also helpful to go to your Discourse profile, then the "emails" tab, and check "Enable mailing list mode".
+1) Join our [Discourse Forum](https://llvm.discourse.group/c/Projects-that-want-to-become-official-LLVM-Projects/circt/)
+on the LLVM Discourse server.  To get a "mailing list" like experience click the
+bell icon in the upper right and switch to "Watching".  It is also helpful to go
+to your Discourse profile, then the "emails" tab, and check "Enable mailing list
+mode".  You can also do chat with us on [CIRCT channel](https://discord.com/channels/636084430946959380/742572728787402763)
+of LLVM discord server.
 
-2) For real-time discussion join the [CIRCT channel](https://discord.com/channels/636084430946959380/742572728787402763) of the LLVM discord server.
-
-3) Join our weekly video chat.  Please see the
+2) Join our weekly video chat.  Please see the
 [meeting notes document](https://docs.google.com/document/d/1fOSRdyZR2w75D87yU2Ma9h2-_lEPL4NxvhJGJd-s5pk/edit#)
 for more information.
 
-4) Contribute code.  CIRCT follows all of the LLVM Policies: you can create pull
-   requests for the CIRCT repository, and gain commit access using the [standard
-   LLVM policies](https://llvm.discourse.group/c/Projects-that-want-to-become-official-LLVM-Projects/circt/).
+3) Contribute code.  CIRCT follows all of the LLVM Policies: you can create pull
+requests for the CIRCT repository, and gain commit access using the [standard LLVM policies](https://llvm.org/docs/DeveloperPolicy.html#obtaining-commit-access).
+
 
 Also take a look at the following diagram, which gives a brief overview of the current [dialects and how they interact](includes/img/dialects.svg):
 <p align="center"><img src="includes/img/dialectlegend.svg"/></p>
@@ -56,5 +59,3 @@ enables new higher-level abstractions for hardware design, and
 perhaps some pieces may even be adopted by proprietary tools in time.
 
 For more information, please see our longer [charter document](docs/Charter.md).
-
-Nightly performance plots: https://circt.org/perf/


### PR DESCRIPTION
Updating _index.md to match the README.md at https://github.com/llvm/circt/blob/main/README.md.

This is just removing https://circt.org/perf/ and the discord channel links and updating the LLVM polices link.